### PR TITLE
Allow supertypes on struct definitions

### DIFF
--- a/src/@aml/@aml_create.jl
+++ b/src/@aml/@aml_create.jl
@@ -73,6 +73,11 @@ function aml_create(expr::Expr, args_param, args_defaultvalue, args_type, args_v
 
         end # endfor
         ################################################################
+        # Remove supertype if it is present
+        if T isa Expr && T.head == :<:
+            T = T.args[1]
+        end
+        ################################################################
         # Type name is a single name (symbol)
         if T isa Symbol
             S = T

--- a/test/struct_definition.jl
+++ b/test/struct_definition.jl
@@ -45,6 +45,21 @@ pprint(pxml_vector)
 @aml mutable struct MyGeneralXML2{T} "MyGeneralXML2"
     myfield::T, "~"
 end
+
+################################################################
+
+abstract type AbstractTestType end
+
+# non-parametric with supertype
+@aml mutable struct MyParentedType <: AbstractTestType "MyParentedType"
+    myfield::String, "~"
+end
+
+# parametric with supertype
+@aml mutable struct MyParentedType2{T} <: AbstractTestType "MyParentedType2"
+    myfield::T, "~"
+end
+
 ################################################################
 
 # empty or no aml

--- a/test/struct_definition.jl
+++ b/test/struct_definition.jl
@@ -55,10 +55,15 @@ abstract type AbstractTestType end
     myfield::String, "~"
 end
 
+@test MyParentedType <: AbstractTestType
+
 # parametric with supertype
 @aml mutable struct MyParentedType2{T} <: AbstractTestType "MyParentedType2"
     myfield::T, "~"
 end
+
+@test MyParentedType2 <: AbstractTestType
+@test MyParentedType2{String} <: AbstractTestType
 
 ################################################################
 


### PR DESCRIPTION
I found supertypes to be useful when I was wrapping a certain XML format, so I (naively) added support and tests. Is there interest in this feature?

* [ ] update documentation